### PR TITLE
Fix TTS engine label text wrapping

### DIFF
--- a/res/layout/preference_tts_engine.xml
+++ b/res/layout/preference_tts_engine.xml
@@ -24,15 +24,15 @@
 
     <RadioButton
         android:id="@+id/tts_engine_radiobutton"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
+        android:layout_weight="1"
         android:clickable="true"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <View
-        android:layout_width="0dp"
+        android:layout_width="2dip"
         android:layout_height="match_parent"
-        android:layout_weight="1"
         android:background="@android:drawable/divider_horizontal_dark" />
 
     <ImageView


### PR DESCRIPTION
If the font size is increased, the gear icon that allows to access
the preferences of a TTS engine can go out of the visible area.

Change-Id: I67a63943a4d1ff8d0f3c7bf10f23bae9be34a40c