### PR TITLE
Fix zen mode allowed event preference summary.

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -362,6 +362,22 @@
     <string name="zen_mode_vibration_calls_only">Only vibrate for calls</string>
     <string name="zen_mode_vibration_calls_and_notifications">Vibrate for calls and notifications</string>
 
+    <!-- Zen mode allowed event setting summary items -->
+    <!-- [CHAR LIMIT=50] Like zen_mode_reminders, but part of a list, so lower case if needed-->
+    <string name="zen_mode_summary_reminders">reminders</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_events, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_events">events</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_all_callers, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_all_callers">all callers</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_selected_callers, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_selected_callers">selected callers</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_repeat_callers, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_repeat_callers">repeat callers</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_all_messages, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_all_messages">all messages</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_selected_messages, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_selected_messages">selected messages</string>
+
     <!-- Notification sound timeout -->
     <string name="app_notification_sound_timeout_title">Minimum time between notification sounds</string>
     <string name="app_notification_sound_timeout_summary_template">Allow sounds or vibration no more than once every <xliff:g id="duration">%1$s</xliff:g></string>

--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -1212,4 +1212,25 @@ public final class Utils extends com.android.settingslib.Utils {
         }
         return false;
     }
+
+    public static String join(Resources res, List<String> items) {
+        final int count = items.size();
+        if (items.isEmpty()) {
+            return null;
+        } else if (count == 1) {
+            return items.get(0);
+        } else if (count == 2) {
+            return res.getString(R.string.join_two_items, items.get(0), items.get(1));
+        } else {
+            String middle = items.get(count - 2);
+            for (int i = count - 3; i > 0; i--) {
+                middle = res.getString(R.string.join_many_items_middle,
+                        items.get(i), middle);
+            }
+            final String allButLast = res.getString(R.string.join_many_items_first,
+                    items.get(0), middle);
+            return res.getString(R.string.join_many_items_last, allButLast,
+                    items.get(count - 1));
+        }
+    }
 }

--- a/src/com/android/settings/notification/ZenModeSettings.java
+++ b/src/com/android/settings/notification/ZenModeSettings.java
@@ -27,7 +27,10 @@ import android.view.MenuItem;
 
 import com.android.internal.logging.MetricsProto.MetricsEvent;
 import com.android.settings.R;
+import com.android.settings.Utils;
 import com.android.settings.SettingsActivity;
+
+import java.util.ArrayList;
 
 public class ZenModeSettings extends ZenModeSettingsBase {
     private static final String KEY_PRIORITY_SETTINGS = "priority_settings";
@@ -79,28 +82,31 @@ public class ZenModeSettings extends ZenModeSettingsBase {
     }
 
     private void updatePrioritySettingsSummary() {
-        String s = getResources().getString(R.string.zen_mode_alarms);
-        s = appendLowercase(s, isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_REMINDERS),
-                R.string.zen_mode_reminders);
-        s = appendLowercase(s, isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_EVENTS),
-                R.string.zen_mode_events);
+        final ArrayList<String> items = new ArrayList<>();
+        items.add(getString(R.string.zen_mode_alarms));
+        if (isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_REMINDERS)) {
+            items.add(getString(R.string.zen_mode_summary_reminders));
+        }
+        if (isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_EVENTS)) {
+            items.add(getString(R.string.zen_mode_summary_events));
+        }
         if (isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_MESSAGES)) {
             if (mPolicy.priorityMessageSenders == Policy.PRIORITY_SENDERS_ANY) {
-                s = appendLowercase(s, true, R.string.zen_mode_all_messages);
+                items.add(getString(R.string.zen_mode_summary_all_messages));
             } else {
-                s = appendLowercase(s, true, R.string.zen_mode_selected_messages);
+                items.add(getString(R.string.zen_mode_summary_selected_messages));
             }
         }
         if (isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_CALLS)) {
             if (mPolicy.priorityCallSenders == Policy.PRIORITY_SENDERS_ANY) {
-                s = appendLowercase(s, true, R.string.zen_mode_all_callers);
+                items.add(getString(R.string.zen_mode_summary_all_callers));
             } else {
-                s = appendLowercase(s, true, R.string.zen_mode_selected_callers);
+                items.add(getString(R.string.zen_mode_summary_selected_callers));
             }
         } else if (isCategoryEnabled(mPolicy, Policy.PRIORITY_CATEGORY_REPEAT_CALLERS)) {
-            s = appendLowercase(s, true, R.string.zen_mode_repeat_callers);
+            items.add(getString(R.string.zen_mode_summary_repeat_callers));
         }
-        mPrioritySettings.setSummary(s);
+        mPrioritySettings.setSummary(Utils.join(getResources(), items));
     }
 
     private void updateVisualSettingsSummary() {
@@ -122,14 +128,6 @@ public class ZenModeSettings extends ZenModeSettingsBase {
 
     private boolean isCategoryEnabled(Policy policy, int categoryType) {
         return (policy.priorityCategories & categoryType) != 0;
-    }
-
-    private String appendLowercase(String s, boolean condition, int resId) {
-        if (condition) {
-            return getResources().getString(R.string.join_many_items_middle, s,
-                    getResources().getString(resId).toLowerCase());
-        }
-        return s;
     }
 
     @Override


### PR DESCRIPTION
Simply using lower-cased versions of other strings might work for
English, but not for most other languages.
Also improve formatting of list: Instead of showing 'a, b, c', show 'a,
b and c'.

Change-Id: I7a809e0655cbde3af1695ec3ddf86ec818fb191d