### PR TITLE
Settings: Strings: Modify a few german summaries

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -3027,16 +3027,16 @@
     <string name="disconnected" msgid="5787956818111197212">"Verbindung getrennt"</string>
     <string name="data_usage_summary_format" msgid="7507047900192160585">"<xliff:g id="AMOUNT">%1$s</xliff:g> genutzt"</string>
     <plurals name="notification_summary" formatted="false" msgid="4019451362120557382">
-      <item quantity="other"><xliff:g id="COUNT_1">%d</xliff:g> Apps, für die das Senden von Benachrichtigungen blockiert ist</item>
-      <item quantity="one"><xliff:g id="COUNT_0">%d</xliff:g> App, für die das Senden von Benachrichtigungen blockiert ist</item>
+      <item quantity="other">Für <xliff:g id="COUNT_1">%d</xliff:g> Apps blockiert</item>
+      <item quantity="one">Für <xliff:g id="COUNT_0">%d</xliff:g> App blockiert</item>
     </plurals>
-    <string name="notification_summary_none" msgid="3440195312233351409">"Alle Apps dürfen Benachrichtigungen senden"</string>
+    <string name="notification_summary_none" msgid="3440195312233351409">"Für alle Apps erlaubt"</string>
     <string name="apps_summary" msgid="193158055537070092">"<xliff:g id="COUNT">%1$d</xliff:g> Apps installiert"</string>
     <string name="apps_summary_example" msgid="2118896966712746139">"24 Apps installiert"</string>
     <string name="storage_summary" msgid="1110250618334248745">"<xliff:g id="SIZE1">%1$s</xliff:g> von <xliff:g id="SIZE2">%2$s</xliff:g> genutzt"</string>
     <string name="display_summary_on" msgid="5628868543070268634">"Adaptive Helligkeit ist AN"</string>
     <string name="display_summary_off" msgid="6399558022426312990">"Adaptive Helligkeit ist AUS"</string>
-    <string name="memory_summary" msgid="8080825904671961872">"Speicher: durchschnittlich <xliff:g id="USED_MEMORY">%1$s</xliff:g> von <xliff:g id="TOTAL_MEMORY">%2$s</xliff:g> belegt"</string>
+    <string name="memory_summary" msgid="8080825904671961872">"Durchschnittlich <xliff:g id="USED_MEMORY">%1$s</xliff:g> von <xliff:g id="TOTAL_MEMORY">%2$s</xliff:g> genutzt"</string>
     <string name="user_summary" msgid="1617826998097722499">"Angemeldet als <xliff:g id="USER_NAME">%1$s</xliff:g>"</string>
     <string name="payment_summary" msgid="3472482669588561110">"Standard: <xliff:g id="APP_NAME">%1$s</xliff:g>"</string>
     <string name="location_on_summary" msgid="5127631544018313587">"AN/<xliff:g id="LOCATION_MODE">%1$s</xliff:g>"</string>


### PR DESCRIPTION
* They take too much space in german
* They also lack accuracy in translation

Change-Id: I7e4119f6534d25cd0ab9c5abe71be45d8ac0f40b