### PR TITLE
Settings: Hide Night Mode suggestion if LiveDisplay feature is present

### DIFF
--- a/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
+++ b/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
@@ -75,7 +75,8 @@ public class SuggestionFeatureProviderImpl implements SuggestionFeatureProvider 
     public boolean isSuggestionCompleted(Context context, @NonNull ComponentName component) {
         final String className = component.getClassName();
         if (className.equals(NightDisplaySuggestionActivity.class.getName())) {
-            return hasUsedNightDisplay(context);
+            return context.getPackageManager().hasSystemFeature("org.lineageos.livedisplay")
+                    || hasUsedNightDisplay(context);
         }
         if (className.equals(NewDeviceIntroSuggestionActivity.class.getName())) {
             return NewDeviceIntroSuggestionActivity.isSuggestionComplete(context);


### PR DESCRIPTION
 * Workaround by forcebly reporting that suggestion has been completed,
   when LiveDisplay is available.

Change-Id: I01f6b3a5acfeeca5468a9926b0bc21247a458dbf