### PR TITLE
Disable toggle for forcing apps to be resizable on Android Go

### DIFF
--- a/src/com/android/settings/development/DevelopmentSettings.java
+++ b/src/com/android/settings/development/DevelopmentSettings.java
@@ -558,6 +558,10 @@ public class DevelopmentSettings extends RestrictedSettingsFragment
         mUSBAudio = findAndInitSwitchPref(USB_AUDIO_KEY);
         mForceResizable = findAndInitSwitchPref(FORCE_RESIZABLE_KEY);
 
+        if (ActivityManager.isLowRamDeviceStatic()) {
+            disableForUser(mForceResizable);
+        }
+
         mImmediatelyDestroyActivities = (SwitchPreference) findPreference(
                 IMMEDIATELY_DESTROY_ACTIVITIES_KEY);
         mAllPrefs.add(mImmediatelyDestroyActivities);


### PR DESCRIPTION
In Developer options, activities can be forced to be resizable,
even if Android Go is enabled. However multi-window is not supported
on Android Go devices, therefore the toggle should be disabled.

Change-Id: I42324d269574c99039785ac572b0c0c2679a08cd