### PR TITLE
Settings: Add an option to force pre-O apps to use full screen aspect…

### DIFF
--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -88,6 +88,10 @@
         android:title="@string/screen_zoom_title"
         settings:keywords="@string/screen_zoom_keywords" />
 
+    <org.lineageos.internal.lineageparts.LineagePartsPreference
+        android:key="long_screen_settings"
+        lineage:requiresConfig="@*lineageos.platform:bool/config_haveHigherAspectRatioScreen" />
+
     <Preference
         android:key="screensaver"
         android:title="@string/screensaver_settings_title"


### PR DESCRIPTION
… ratio

When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change aspect ratio
for pre-O apps to full screen aspect ratio.

Change-Id: I0fb73511cf654ee22a4cfb7aef252008f8db8855