### PR TITLE
SimSettings: Use TelephonyExtUtils helper methods

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -32,8 +32,7 @@ LOCAL_JAVA_LIBRARIES := \
     bouncycastle \
     core-oj \
     telephony-common \
-    ims-common \
-    telephony-ext
+    ims-common
 
 LOCAL_STATIC_JAVA_LIBRARIES := \
     jsr305 \

--- a/src/com/android/settings/sim/SimSettings.java
+++ b/src/com/android/settings/sim/SimSettings.java
@@ -19,26 +19,20 @@ package com.android.settings.sim;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.os.RemoteException;
-import android.os.ServiceManager;
 import android.os.SystemProperties;
 import android.provider.SearchIndexableResource;
 import android.provider.Settings;
 import android.support.v7.preference.Preference;
-import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.PreferenceGroup;
-import android.support.v7.preference.PreferenceManager;
 import android.support.v7.preference.PreferenceScreen;
 import android.support.v7.preference.PreferenceViewHolder;
 import android.telecom.PhoneAccount;
@@ -50,16 +44,12 @@ import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
-import android.util.AttributeSet;
 import android.util.Log;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
-import com.android.internal.telephony.PhoneConstants;
 import com.android.internal.telephony.TelephonyProperties;
 import com.android.settings.R;
 import com.android.settings.RestrictedSettingsFragment;
@@ -67,22 +57,19 @@ import com.android.settings.Utils;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.search.Indexable;
 
-import org.codeaurora.internal.IExtTelephony;
+import org.lineageos.internal.util.TelephonyExtUtils;
+import org.lineageos.internal.util.TelephonyExtUtils.ProvisioningChangedListener;
 
-import java.lang.NoClassDefFoundError;
+import static org.lineageos.internal.util.TelephonyExtUtils.PROVISIONED;
+import static org.lineageos.internal.util.TelephonyExtUtils.NOT_PROVISIONED;
+
 import java.util.ArrayList;
 import java.util.List;
 
-public class SimSettings extends RestrictedSettingsFragment implements Indexable {
+public class SimSettings extends RestrictedSettingsFragment implements Indexable,
+        ProvisioningChangedListener {
     private static final String TAG = "SimSettings";
     private static final boolean DBG = false;
-
-    // These are the list of  possible values that
-    // IExtTelephony.getCurrentUiccCardProvisioningStatus() can return
-    private static final int PROVISIONED = 1;
-    private static final int NOT_PROVISIONED = 0;
-    private static final int INVALID_STATE = -1;
-    private static final int CARD_NOT_PRESENT = -2;
 
     private static final String DISALLOW_CONFIG_SIM = "no_config_sim";
     private static final String SIM_CARD_CATEGORY = "sim_cards";
@@ -104,7 +91,6 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
     private SubscriptionManager mSubscriptionManager;
     private int mNumSlots;
     private Context mContext;
-    private IExtTelephony mExtTelephony;
 
     private int mPhoneCount = TelephonyManager.getDefault().getPhoneCount();
     private int[] mCallState = new int[mPhoneCount];
@@ -114,10 +100,6 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
     private ProgressDialog mProgressDialog = null;
     private boolean mNeedsUpdate = false;
     private int[] mUiccProvisionStatus = new int[mPhoneCount];
-
-    private static final String ACTION_UICC_MANUAL_PROVISION_STATUS_CHANGED =
-            "org.codeaurora.intent.action.ACTION_UICC_MANUAL_PROVISION_STATUS_CHANGED";
-    private static final String EXTRA_NEW_PROVISION_STATE = "newProvisionState";
 
     public SimSettings() {
         super(DISALLOW_CONFIG_SIM);
@@ -136,12 +118,6 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
         mSubscriptionManager = SubscriptionManager.from(getActivity());
         final TelephonyManager tm =
                 (TelephonyManager) getActivity().getSystemService(Context.TELEPHONY_SERVICE);
-        try {
-            mExtTelephony = IExtTelephony.Stub.asInterface(ServiceManager.getService("extphone"));
-        } catch (NoClassDefFoundError ex) {
-            // ignore, device does not compile telephony-ext.
-        }
-
         addPreferencesFromResource(R.xml.sim_settings);
 
         mNumSlots = tm.getSimCount();
@@ -150,15 +126,18 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
         mSelectableSubInfos = new ArrayList<SubscriptionInfo>();
         SimSelectNotification.cancelNotification(getActivity());
 
-        IntentFilter intentFilter = new IntentFilter(ACTION_UICC_MANUAL_PROVISION_STATUS_CHANGED);
-        mContext.registerReceiver(mReceiver, intentFilter);
+        TelephonyExtUtils.getInstance(mContext).addListener(this);
     }
 
     @Override
     public void onDestroy() {
-        mContext.unregisterReceiver(mReceiver);
-        Log.d(TAG,"on onDestroy");
+        TelephonyExtUtils.getInstance(mContext).removeListener(this);
         super.onDestroy();
+    }
+
+    @Override
+    public void onProvisioningChanged(int slotId, boolean isProvisioned) {
+        updateSubscriptions();
     }
 
     private final SubscriptionManager.OnSubscriptionsChangedListener mOnSubscriptionsChangeListener
@@ -467,6 +446,10 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
                     Settings.Global.AIRPLANE_MODE_ON, 0) != 0);
         }
 
+        private boolean isSlotProvisioned(int slotId) {
+            return getProvisionStatus(slotId) == PROVISIONED;
+        }
+
         private int getProvisionStatus(int slotId) {
             return mUiccProvisionStatus[slotId];
         }
@@ -480,7 +463,7 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
 
             // Hide manual provisioning if the extphone framework
             // is not present, as the operation relies on said framework.
-            if (mExtTelephony == null ||
+            if (!TelephonyExtUtils.getInstance(mContext).hasService() ||
                    !mContext.getResources().getBoolean(R.bool.config_enableManualSubProvisioning)) {
                 mSwitch.setVisibility(View.GONE);
             } else {
@@ -490,28 +473,20 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
                 } else {
                     mSwitch.setEnabled(true);
                 }
-                setChecked(getProvisionStatus(mSlotId) == PROVISIONED);
+                setChecked(isSlotProvisioned(mSlotId));
             }
         }
 
         @Override
         public void update() {
-            final Resources res = mContext.getResources();
             logd("update()" + mSubInfoRecord);
 
-            if (mExtTelephony != null) {
-                try {
-                    //get current provision state of the SIM.
-                    mUiccProvisionStatus[mSlotId] =
-                            mExtTelephony.getCurrentUiccCardProvisioningStatus(mSlotId);
-                } catch (RemoteException ex) {
-                    mUiccProvisionStatus[mSlotId] = INVALID_STATE;
-                    loge("Failed to get pref, slotId: "+ mSlotId +" Exception: " + ex);
-                }
-            } else {
-                // if we don't have telephony-ext, assume provisioned state
-                mUiccProvisionStatus[mSlotId] = PROVISIONED;
-            }
+            // Get current provision state of the SIM,
+            // assuming it as provisioned if extphone framework is not present
+            TelephonyExtUtils extTelephony = TelephonyExtUtils.getInstance(mContext);
+            mUiccProvisionStatus[mSlotId] = extTelephony.hasService() ?
+                    extTelephony.getCurrentUiccCardProvisioningStatus(mSlotId) :
+                    PROVISIONED;
 
             super.update();
         }
@@ -553,7 +528,7 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
 
         @Override
         protected CharSequence determineSummary() {
-            if (getProvisionStatus(mSlotId) != PROVISIONED) {
+            if (!isSlotProvisioned(mSlotId)) {
                 CharSequence state = mContext.getString(
                         hasCard() ? R.string.sim_disabled : R.string.sim_missing);
                 return mContext.getString(R.string.sim_enabler_summary,
@@ -574,7 +549,7 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
                     mSubscriptionManager.getActiveSubscriptionInfoList();
             if (subInfoLists != null) {
                 for (SubscriptionInfo subInfo : subInfoLists) {
-                    if (getProvisionStatus(subInfo.getSimSlotIndex()) == PROVISIONED) {
+                    if (isSlotProvisioned(subInfo.getSimSlotIndex())) {
                         activeSubInfoCount++;
                     }
                 }
@@ -650,20 +625,12 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
 
             @Override
             protected Integer doInBackground(Void... params) {
-                int result = -1;
-                newProvisionedState = NOT_PROVISIONED;
-                try {
-                    if (mIsChecked) {
-                        result = mExtTelephony.activateUiccCard(mSlotId);
-                        newProvisionedState = PROVISIONED;
-                    } else {
-                        result = mExtTelephony.deactivateUiccCard(mSlotId);
-                    }
-                } catch (RemoteException ex) {
-                    loge("Activate  sub failed " + result + " phoneId " + mSlotId);
-                } catch (NullPointerException ex) {
-                    loge("Failed to activate sub Exception: " + ex);
-                }
+                TelephonyExtUtils extTelephony = TelephonyExtUtils.getInstance(mContext);
+                int result = mIsChecked ?
+                        extTelephony.activateUiccCard(mSlotId) :
+                        extTelephony.deactivateUiccCard(mSlotId);
+                newProvisionedState =
+                        extTelephony.getCurrentUiccCardProvisioningStatus(mSlotId);
                 return result;
             }
 
@@ -738,7 +705,7 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
                     mSubscriptionManager.getActiveSubscriptionInfoList();
             if (subInfoLists != null) {
                 for (SubscriptionInfo subInfo : subInfoLists) {
-                    if (getProvisionStatus(subInfo.getSimSlotIndex()) == PROVISIONED
+                    if (isSlotProvisioned(subInfo.getSimSlotIndex())
                             && subInfo.getSubscriptionId() != mSubInfoRecord.getSubscriptionId())
                         activeSlotId = subInfo.getSimSlotIndex() + 1;
                 }
@@ -893,21 +860,4 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
         Log.d(TAG, "isCallStateIdle " + callStateIdle);
         return callStateIdle;
     }
-
-    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            String action = intent.getAction();
-            Log.d(TAG, "Intent received: " + action);
-            if (ACTION_UICC_MANUAL_PROVISION_STATUS_CHANGED.equals(action)) {
-                int phoneId = intent.getIntExtra(PhoneConstants.PHONE_KEY,
-                        SubscriptionManager.INVALID_SUBSCRIPTION_ID);
-                int newProvisionedState = intent.getIntExtra(EXTRA_NEW_PROVISION_STATE,
-                        NOT_PROVISIONED);
-                 updateSubscriptions();
-                 Log.d(TAG, "Received ACTION_UICC_MANUAL_PROVISION_STATUS_CHANGED on phoneId: "
-                         + phoneId + " new sub state " + newProvisionedState);
-            }
-        }
-    };
 }


### PR DESCRIPTION
 * TelephonyExtUtils class was recently added to Lineage SDK,
   thus allowing to clean up much of the code introduced
   for manual SIM provisioning.

Change-Id: Id6eaffffb3c2b2b2dead36e0f56d8547e6188690