### PR TITLE
SimSettings: Fix preferred calls sim not being disabled

### DIFF
--- a/src/com/android/settings/sim/SimSettings.java
+++ b/src/com/android/settings/sim/SimSettings.java
@@ -247,7 +247,7 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
         simPref.setSummary(account == null
                 ? mContext.getResources().getString(R.string.sim_calls_ask_first_prefs_title)
                 : (String) account.getLabel());
-        simPref.setEnabled(allPhoneAccounts.size() > 1);
+        simPref.setEnabled(allPhoneAccounts.size() > 1 && mSelectableSubInfos.size() > 1);
     }
 
     @Override


### PR DESCRIPTION
* When disabling a sim on a dual sim device, the selection
  would not be disabled properly

Change-Id: Ib8054f724ae974640491d03c668066db47b8a3a9