### PR TITLE
DisplaySettings: Allow devices to opt out from lift to wake detection

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -130,4 +130,7 @@
 
     <!-- Whether notify user that switch data service -->
     <bool name="confirm_to_switch_data_service">false</bool>
+
+    <!-- Whether device supports lift to wake -->
+    <bool name="config_supportsLiftToWake">true</bool>
 </resources>

--- a/src/com/android/settings/display/LiftToWakePreferenceController.java
+++ b/src/com/android/settings/display/LiftToWakePreferenceController.java
@@ -37,7 +37,9 @@ public class LiftToWakePreferenceController extends AbstractPreferenceController
     @Override
     public boolean isAvailable() {
         SensorManager sensors = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
-        return sensors != null && sensors.getDefaultSensor(Sensor.TYPE_WAKE_GESTURE) != null;
+        return mContext.getResources().getBoolean(
+                com.android.settings.R.bool.config_supportsLiftToWake) &&
+                sensors != null && sensors.getDefaultSensor(Sensor.TYPE_WAKE_GESTURE) != null;
     }
 
     @Override


### PR DESCRIPTION
 * Some devices provide TYPE_WAKE_GESTURE sensor that isn't being used
   for lift to wake therefore we need to hide this feature on these devices.

Change-Id: Ia1b6737a02777dfcd3c80cab62f128a3090807fa
Signed-off-by: Giuseppe Barillari <joe2k01dev@gmail.com>