### PR TITLE
Display correct device type in lock screen suggestion

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1167,7 +1167,9 @@
     <!-- Security Picker --><skip />
 
     <!-- Title for suggested actions for screen lock [CHAR LIMIT=46] -->
-    <string name="suggested_lock_settings_title">Secure your phone</string>
+    <string name="suggested_lock_settings_title" product="tablet">Secure your tablet</string>
+    <string name="suggested_lock_settings_title" product="device">Secure your device</string>
+    <string name="suggested_lock_settings_title" product="default">Secure your phone</string>
 
     <!-- Summary for suggested actions for screen lock (tablet) [CHAR LIMIT=55] -->
     <string name="suggested_lock_settings_summary" product="tablet">Set screen lock to protect tablet</string>


### PR DESCRIPTION
Show "phone" for phone, "tablet" for tablet, "device" for everything else

Change-Id: I0d3398d2fe366b5060f24c612494c692678e813c