### PR TITLE
lockscreen: Forward port option to pass swipe-up-to-unlock

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -113,4 +113,8 @@
     <!-- Touchscreen hovering -->
     <string name="touchscreen_hovering_title">Touchscreen hovering</string>
     <string name="touchscreen_hovering_summary">Allows you to hover the screen like a mouse in web browsers, remote desktops, etc</string>
+
+    <!-- Whether the keyguard will directly show the lock entry -->
+    <string name="directly_show_lock">Direct unlock</string>
+    <string name="directly_show_lock_summary">Skip the swipe to unlock screen and immediately begin key entry</string>
 </resources>

--- a/res/xml/screen_lock_settings.xml
+++ b/res/xml/screen_lock_settings.xml
@@ -46,6 +46,12 @@
         android:key="power_button_instantly_locks"
         android:title="@string/lockpattern_settings_enable_power_button_instantly_locks" />
 
+    <!-- available in pin/pattern/password -->
+    <SwitchPreference
+        android:key="directly_show_lock"
+        android:title="@string/directly_show_lock"
+        android:summary="@string/directly_show_lock_summary" />
+
     <!-- available in pin/pattern/password/slide -->
     <com.android.settingslib.RestrictedPreference
         android:key="owner_info_settings"

--- a/src/com/android/settings/security/screenlock/DirectlyShowLockPreferenceController.java
+++ b/src/com/android/settings/security/screenlock/DirectlyShowLockPreferenceController.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ * Copyright (C) 2018 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.security.screenlock;
+
+import android.app.admin.DevicePolicyManager;
+import android.content.Context;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.TwoStatePreference;
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+
+import lineageos.providers.LineageSettings;
+
+import org.lineageos.internal.util.LineageLockPatternUtils;
+
+public class DirectlyShowLockPreferenceController extends AbstractPreferenceController
+        implements PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_DIRECTLY_SHOW_LOCK = "directly_show_lock";
+
+    private final int mUserId;
+    private final LockPatternUtils mLockPatternUtils;
+    private final LineageLockPatternUtils mLineageLockPatternUtils;
+
+    public DirectlyShowLockPreferenceController(Context context, int userId,
+            LockPatternUtils lockPatternUtils) {
+        super(context);
+        mUserId = userId;
+        mLockPatternUtils = lockPatternUtils;
+        mLineageLockPatternUtils = new LineageLockPatternUtils(context);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        if (!mLockPatternUtils.isSecure(mUserId)) {
+            return false;
+        }
+        switch (mLockPatternUtils.getKeyguardStoredPasswordQuality(mUserId)) {
+            case DevicePolicyManager.PASSWORD_QUALITY_SOMETHING:
+            case DevicePolicyManager.PASSWORD_QUALITY_NUMERIC:
+            case DevicePolicyManager.PASSWORD_QUALITY_NUMERIC_COMPLEX:
+            case DevicePolicyManager.PASSWORD_QUALITY_ALPHABETIC:
+            case DevicePolicyManager.PASSWORD_QUALITY_ALPHANUMERIC:
+            case DevicePolicyManager.PASSWORD_QUALITY_COMPLEX:
+            case DevicePolicyManager.PASSWORD_QUALITY_MANAGED:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        ((TwoStatePreference) preference).setChecked(
+                mLineageLockPatternUtils.shouldPassToSecurityView(mUserId));
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_DIRECTLY_SHOW_LOCK;
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        mLineageLockPatternUtils.setPassToSecurityView((Boolean) newValue, mUserId);
+        return true;
+    }
+}

--- a/src/com/android/settings/security/screenlock/ScreenLockSettings.java
+++ b/src/com/android/settings/security/screenlock/ScreenLockSettings.java
@@ -82,6 +82,8 @@ public class ScreenLockSettings extends DashboardFragment
                 context, MY_USER_ID, lockPatternUtils));
         controllers.add(new PowerButtonInstantLockPreferenceController(
                 context, MY_USER_ID, lockPatternUtils));
+        controllers.add(new DirectlyShowLockPreferenceController(
+                context, MY_USER_ID, lockPatternUtils));
         controllers.add(new LockAfterTimeoutPreferenceController(
                 context, MY_USER_ID, lockPatternUtils));
         controllers.add(new PinScramblePreferenceController(


### PR DESCRIPTION
sam3000: fixups for pie
original commit message:

 * Adapt settings to Nougat SecuritySubSettings class
 * Interface switches in security_settings_*_sub.xml
 * Additional changes for dependencies
 * Cleanup the names to 'directly_show_lock'
 * Reorder the new preferences

lockscreen: Add option to pass swipe-up-to-unlock (2/3)

* Option appears on PIN,pattern and password methods
* User should press back button to see notifications, clock etc.
* Instantly hides keyguard if Smart Lock has unlocked phone.

CYNGNOS-1873
Change-Id: I31256770869b20842c69edb4a7a57b2bad7b3ea7
Signed-off-by: eray orçunus <erayorcunus@gmail.com>