### PR TITLE
Settings: Hide Night Mode suggestion if LiveDisplay feature is present

### DIFF
--- a/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
+++ b/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
@@ -86,7 +86,8 @@ public class SuggestionFeatureProviderImpl implements SuggestionFeatureProvider 
         } else if (className.equals(WifiCallingSuggestionActivity.class.getName())) {
             return WifiCallingSuggestionActivity.isSuggestionComplete(context);
         } else if (className.equals(NightDisplaySuggestionActivity.class.getName())) {
-            return NightDisplayPreferenceController.isSuggestionComplete(context);
+            return context.getPackageManager().hasSystemFeature("org.lineageos.livedisplay")
+                    || NightDisplayPreferenceController.isSuggestionComplete(context);
         } else if (className.equals(NewDeviceIntroSuggestionActivity.class.getName())) {
             return NewDeviceIntroSuggestionActivity.isSuggestionComplete(context);
         } else if (className.equals(ZenSuggestionActivity.class.getName())) {


### PR DESCRIPTION
 * Workaround by forcebly reporting that suggestion has been completed,
   when LiveDisplay is available.

Change-Id: I01f6b3a5acfeeca5468a9926b0bc21247a458dbf