### PR TITLE
SimSettings: Add manual SIM provisioning support

### DIFF
--- a/res/layout/custom_sim_switch.xml
+++ b/res/layout/custom_sim_switch.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ /* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+-->
+<Switch xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/sub_switch_widget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:clickable="true"
+    android:focusable="false"
+    android:padding="8dip" />

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -87,6 +87,21 @@
     <!-- Lock screen visualizer -->
     <string name="lockscreen_visualizer_title">Display music visualizer</string>
 
+    <!-- Manual provisioning support -->
+    <string name="sim_enabler_summary"><xliff:g id="displayName">%1$s</xliff:g> is <xliff:g id="status" example="disabled">%2$s</xliff:g></string>
+    <string name="sim_disabled">disabled</string>
+    <string name="sim_missing">missing or faulty</string>
+    <string name="sim_enabler_need_disable_sim">SIM card will be deactivated. Do you want to continue?</string>
+    <string name="sim_enabler_airplane_on">Unable to perform the operation while airplane mode is on.</string>
+    <string name="sim_enabler_in_call">Unable to perform the operation while in call.</string>
+    <string name="sim_enabler_both_inactive">Can\'t disable all SIM cards</string>
+    <string name="sim_enabler_enabling">Activating\u2026</string>
+    <string name="sim_enabler_disabling">Deactivating\u2026</string>
+    <string name="sub_activate_success">SIM activated.</string>
+    <string name="sub_activate_failed">Activation failed.</string>
+    <string name="sub_deactivate_success">SIM deactivated.</string>
+    <string name="sub_deactivate_failed">Deactivation failed.</string>
+
     <!-- Per-app data restrictions -->
     <string name="data_usage_app_restrict_data">Cellular data</string>
     <string name="data_usage_app_restrict_data_summary">Enable usage of cellular data</string>

--- a/res/values/lineage_config.xml
+++ b/res/values/lineage_config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 The CyanogenMod Project
+     Copyright (C) 2018 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Does the device allow for manual subscription provisioning? Only works for multi-sim devices,
+         and depends on QC's proprietary telephony stack or OSS telephony-ext implementation -->
+    <bool name="config_enableManualSubProvisioning">true</bool>
+</resources>


### PR DESCRIPTION
Author: Chaitanya Saggurthi <csaggurt@codeaurora.org>
Date:   Thu Jul 16 16:33:34 2015 +0530

    Telephony(MSIM): Add Manual provisioning support

    Add toggle switch UI option in SimSettings screen to
    enable/disable SIM cards

    Change-Id: Id07271aedb12eabc0b106ac278ba2e12c71cfe03

Author: Sandeep Gutta <sangutta@codeaurora.org>
Date:   Mon Aug 10 15:09:59 2015 +0530

    Telephony(MSIM): Manual provision related fixes

    - Consider Manual provision state while displaying
      active sub info list.
    - Enable sms/data user preference option only
    - Enable sms/data user preference option only
      if more than one subscription active.
    - Introduce below system proeprty to control AOSP
      behavior of user selection of fallback preference
      for sms/data
      "persist.radio.aosp_usr_pref_sel"

    Change-Id: I2b308b801f3f677c5a3ffaee5a8e6beda12aedd2

Author: Sandeep Gutta <sangutta@codeaurora.org>
Date:   Sun Sep 13 22:09:23 2015 +0530

    Telephony(MSIM): Fix to do not allow both SIM deactivation

    Use proper SubInfo record object to do not allow
    user to deactivate both SIMs on DSDS devices.

    Change-Id: I6f56d819367272b3a009c7a8133709c643e8bd84
    CRs-Fixed: 893504

Author: Sandeep Gutta <sangutta@codeaurora.org>
Date:   Mon Sep 14 20:14:07 2015 +0530

    Telephony(MSIM): Select preferred primary sub.

    Add UI to select preferred primary sub.
    It is used when two SIM cards inserted have same
    priority as per policy.

    Change-Id: I5726fe9f4df03e680dc2406854d08da77297444d

Author: Ricardo Cerqueira <ricardo@cyngn.com>
Date:   Thu Nov 5 18:23:52 2015 +0000

    Break MSIM dependency on qci-telephony-framework

    If the provisioning state is invalid, the framework is most likely
    absent. Consider the card as provisioned to pass all relevant checks.

    Change-Id: I975ff156e4328e9d3f6e2626a863bbacb29e3337

Author: LuK1337 <priv.luk@gmail.com>
Date:   Sun Jan 3 22:32:00 2016 +0100

    Hide manual provisioning switch when extphone framework is not present

    * It doesn't work without it.

    Change-Id: Iec11ec2006059f26668f2a6fee4c2c9ca6650119

Author: LuK1337 <priv.luk@gmail.com>
Date:   Sun Jul 3 22:11:26 2016 +0200

    Settings: Don't set the icon for sim activation / deactivation dialog

    * This icon doesn't look any good.
      It's better to just get rid of it.

    Change-Id: I47f70a80136695e9aa61ff98999a2cf770390079

Author: Luca Stefani <luca.stefani.ge1@gmail.com>
Date:   Sun Jul 3 21:56:08 2016 +0200

    Settings: Disable sim switch if subscription isn't valid

    Change-Id: I22ba9a3270da13f77fdd43586b7dc487f0929453

Author: Venkatraman Nerellapalli <venkataraman.nerellapalli@codeaurora.org>
Date:   Sat Jan 9 17:20:00 2016 +0530

    Telephony(MSIM): Fix ANR on SIM deactivation

    Dismiss dialog box on confirmation.
    SIM activation & deactivation in background thread.

    Change-Id: I0268a710f35e30b2abec3dd671942b52fc0e0b46
    CRs-Fixed: 957308

Author: Ricardo Cerqueira <ricardo@cyngn.com>
Date:   Thu Jul 28 12:29:40 2016 +0100

    SimSettings: Make provisioning optional even if qti-telephony is present

    Current code assumes the manual provisioning options should come
    up if the qti-telephony blob is present. Don't make that assumption.

    Change-Id: I5e4f28b628e3fe3fe9e506631e92c85103e87ccf

Author: Danny Baumann <dannybaumann@web.de>
Date:   Tue Feb 28 12:26:37 2017 +0100

    Clean up SIM enable toggle implementation

    - Move strings to cm_strings.xml
    - Improve string wording
    - Remove unused code
    - Streamline implementation

    Change-Id: I58fc3002cfcc37dd1798819223289cc541bed211

Author: Danny Baumann <dannybaumann@web.de>
Date:   Thu Feb 16 14:50:56 2017 +0100

    Fix possible NPE on SIM settings shutdown.

    Change-Id: Ibf6b54fc2b97a780cfd7ace17c54855ef7e70c57

Author: xyyx <xyyx@mail.ru>
Date:   Fri Jan 19 23:31:36 2018 +0800

    SimSettings: Correctly disable sim switch without SIM card

    * Code extracted from MM CAF

    Change-Id: I59924806302c57e5652b18235e50c9569153dbd3

Author: maxwen <max.weninger@gmail.com>
Date:   Sat Jan 20 13:39:17 2018 +0100

    SimSettings: Improve dialogs

    Squash of:

    Settings: no need to show a success alert dialog on sim switch

    very 'un-android-like' :)

    Change-Id: Ie68eed174464d7acf67171a509a19045e0d9c669

    Settings: fix neverending progress on sim activation change

    what a stupid bug....

    and while we are here - also the confirm dialog on
    deactivation is actually useless - using the switch
    should be more enough to not always ask and anoy user
    if he really knows what he is doing

    Change-Id: I38eb17cf8d12259f34b339da2ad807d12a5c0d41

Author: LuK1337 <priv.luk@gmail.com>
Date:   Fri Jan 26 18:39:50 2018 +0100

    SimSettings: Handle NoClassDefFoundError on devices without telephony-ext

    Change-Id: I9f4a2c773d8ad1d82993ea19bf9ee5e70e5d0516

Author: Bruno Martins <bgcngm@gmail.com>
Date:   Tue Jun 5 18:51:25 2018 +0100

    SimSettings: Use TelephonyExtUtils helper methods

     * TelephonyExtUtils class was recently added to Lineage SDK,
       thus allowing to clean up much of the code introduced
       for manual SIM provisioning.

    Change-Id: Id6eaffffb3c2b2b2dead36e0f56d8547e6188690

Author: Paul Keith <javelinanddart@gmail.com>
Date:   Wed Jun 27 01:00:02 2018 +0200

    Settings: Cleanup SimSettings additions

    * This shouldn't be an overlay, and is resulting in dead code

    Change-Id: I86bef790463ff5d40541f849f2d5e9fc1ae238c2

Change-Id: I42e76651da449a6a82f95d6930384693cb04b26d