### PR TITLE
Settings: Add back summary_collapsed_preference_list for zh-rCN

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -16,6 +16,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="summary_collapsed_preference_list" msgid="5190123168583152844">"<xliff:g id="CURRENT_ITEMS">%1$s</xliff:g>、<xliff:g id="ADDED_ITEMS">%2$s</xliff:g>"</string>
     <string name="yes" msgid="4676390750360727396">"是"</string>
     <string name="no" msgid="6731231425810196216">"否"</string>
     <string name="create" msgid="3578857613172647409">"创建"</string>


### PR DESCRIPTION
 * AOSP commit 0301470 incorrectly reverted commit 03fb1a9,
   which is needed to show correct advanced button preference
   string for zh-rCN.

Change-Id: Ifb428e4995c7609558ed2efcfaddd5c84ee04b04