### PR TITLE
wifi: Remove Qr Code scanner during Modify Network option.

### DIFF
--- a/src/com/android/settings/wifi/WifiConfigController.java
+++ b/src/com/android/settings/wifi/WifiConfigController.java
@@ -977,6 +977,8 @@ public class WifiConfigController implements TextWatcher,
 
             if (mAccessPoint != null && mAccessPoint.isSaved()) {
                 mPasswordView.setHint(R.string.wifi_unchanged);
+                // Disable Password Scanner for "Modify Network"
+                mPasswordScanButton.setVisibility(View.GONE);
             }
         }
 


### PR DESCRIPTION
Currently, Qr Code Scanner button (Image) is provided alongside of
modify password text field which doesn't have onClick action defined.
Thus, Qr Code scanner is not launched.

Considering no strong use case of Qr Code scanner during modify
network, this CL removes Qr code scanner button from modify network
options.

Change-Id: Ie2391853331a0ccf26a699f5ed4039da2769ec3f
CRs-Fixed: 2493423