### PR TITLE
development: Add setting for updating recovery

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -141,4 +141,10 @@
     <!-- Touchscreen hovering -->
     <string name="touchscreen_hovering_title">Touchscreen hovering</string>
     <string name="touchscreen_hovering_summary">Allows you to hover the screen like a mouse in web browsers, remote desktops, etc</string>
+
+    <!-- Update recovery -->
+    <string name="update_recovery_title">Update recovery</string>
+    <string name="update_recovery_summary">Update the built-in recovery with system updates</string>
+    <string name="update_recovery_on_warning">NOTICE: When this feature is enabled, your installed recovery will be replaced by one included with the current version of the running OS.\n\nYour recovery will be updated along with upgrades to your system, helping to ensure compatibility with future versions.\n\nWould you like to enable this feature?</string>
+    <string name="update_recovery_off_warning">WARNING: When this feature is disabled, your installed recovery will not be updated with OS upgrades.\n\nFuture OS updates may not install with outdated or custom recovery versions.\n\nDo you really want to disable this feature?</string>
 </resources>

--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -136,6 +136,11 @@
         android:key="security_setting_trust_lost_locks_screen"
         android:title="@string/trust_lost_locks_screen_title"
         android:summary="@string/trust_lost_locks_screen_summary" />
+
+    <SwitchPreference
+        android:key="update_recovery"
+        android:title="@string/update_recovery_title"
+        android:summary="@string/update_recovery_summary" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
+++ b/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
@@ -62,6 +62,7 @@ import java.util.List;
 public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFragment
         implements SwitchBar.OnSwitchChangeListener, OemUnlockDialogHost, AdbDialogHost,
         WirelessAdbDialogHost, AdbClearKeysDialogHost, LogPersistDialogHost,
+        UpdateRecoveryDialogHost,
         BluetoothA2dpHwOffloadRebootDialog.OnA2dpHwDialogConfirmedListener {
 
     private static final String TAG = "DevSettingsDashboard";
@@ -300,6 +301,20 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
     }
 
     @Override
+    public void onUpdateRecoveryDialogConfirmed() {
+        final UpdateRecoveryPreferenceController controller = getDevelopmentOptionsController(
+                UpdateRecoveryPreferenceController.class);
+        controller.onUpdateRecoveryDialogConfirmed();
+    }
+
+    @Override
+    public void onUpdateRecoveryDialogDismissed() {
+        final UpdateRecoveryPreferenceController controller = getDevelopmentOptionsController(
+                UpdateRecoveryPreferenceController.class);
+        controller.onUpdateRecoveryDialogDismissed();
+    }
+
+    @Override
     public void onA2dpHwDialogConfirmed() {
         final BluetoothA2dpHwOffloadPreferenceController controller =
                 getDevelopmentOptionsController(BluetoothA2dpHwOffloadPreferenceController.class);
@@ -433,6 +448,7 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
         controllers.add(new AdbRootPreferenceController(context, fragment));
         controllers.add(new WirelessAdbPreferenceController(context, fragment));
         controllers.add(new ClearAdbKeysPreferenceController(context, fragment));
+        controllers.add(new UpdateRecoveryPreferenceController(context, fragment));
         controllers.add(new LocalTerminalPreferenceController(context));
         controllers.add(new BugReportInPowerPreferenceController(context));
         controllers.add(new AutomaticSystemServerHeapDumpPreferenceController(context));

--- a/src/com/android/settings/development/UpdateRecoveryDialogHost.java
+++ b/src/com/android/settings/development/UpdateRecoveryDialogHost.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.development;
+
+/**
+ * Interface for UpdateRecoveryWarningDialogFragment callbacks.
+ */
+public interface UpdateRecoveryDialogHost {
+
+    /**
+     * Called when the user presses ok on the warning dialog.
+     */
+    void onUpdateRecoveryDialogConfirmed();
+
+    /**
+     * Called when the user dismisses or cancels the warning dialog.
+     */
+    void onUpdateRecoveryDialogDismissed();
+}

--- a/src/com/android/settings/development/UpdateRecoveryPreferenceController.java
+++ b/src/com/android/settings/development/UpdateRecoveryPreferenceController.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.development;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.os.UserManager;
+import android.text.TextUtils;
+
+import androidx.annotation.VisibleForTesting;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.R;
+import com.android.settings.Utils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.development.DeveloperOptionsPreferenceController;
+
+import java.io.File;
+
+public class UpdateRecoveryPreferenceController extends DeveloperOptionsPreferenceController
+        implements PreferenceControllerMixin {
+
+    private static final String TAG = "UpdateRecoveryPreferenceController";
+    private static final String PREF_KEY = "update_recovery";
+
+    private static final String UPDATE_RECOVERY_EXEC = "/system/bin/install-recovery.sh";
+    private static final String UPDATE_RECOVERY_PROPERTY = "persist.sys.recovery_update";
+
+    private final DevelopmentSettingsDashboardFragment mFragment;
+
+    public UpdateRecoveryPreferenceController(Context context,
+            DevelopmentSettingsDashboardFragment fragment) {
+        super(context);
+
+        mFragment = fragment;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return new File(UPDATE_RECOVERY_EXEC).exists();
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return PREF_KEY;
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+
+        boolean enabled = SystemProperties.getBoolean(UPDATE_RECOVERY_PROPERTY, false);
+        ((SwitchPreference) mPreference).setChecked(enabled);
+
+        if (!isAdminUser()) {
+            mPreference.setEnabled(false);
+        }
+    }
+
+    @Override
+    public boolean handlePreferenceTreeClick(Preference preference) {
+        if (Utils.isMonkeyRunning()) {
+            return false;
+        }
+
+        if (TextUtils.equals(preference.getKey(), getPreferenceKey())) {
+            UpdateRecoveryWarningDialog.show(mFragment);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onDeveloperOptionsSwitchEnabled() {
+        if (isAdminUser()) {
+            mPreference.setEnabled(true);
+        }
+    }
+
+    public void onUpdateRecoveryDialogConfirmed() {
+        boolean enabled = SystemProperties.getBoolean(UPDATE_RECOVERY_PROPERTY, false);
+        SystemProperties.set(UPDATE_RECOVERY_PROPERTY, String.valueOf(!enabled));
+        ((SwitchPreference) mPreference).setChecked(!enabled);
+    }
+
+    public void onUpdateRecoveryDialogDismissed() {
+        boolean enabled = SystemProperties.getBoolean(UPDATE_RECOVERY_PROPERTY, false);
+        ((SwitchPreference) mPreference).setChecked(enabled);
+    }
+
+    @VisibleForTesting
+    boolean isAdminUser() {
+        return ((UserManager) mContext.getSystemService(Context.USER_SERVICE)).isAdminUser();
+    }
+}

--- a/src/com/android/settings/development/UpdateRecoveryWarningDialog.java
+++ b/src/com/android/settings/development/UpdateRecoveryWarningDialog.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.development;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.os.SystemProperties;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.R;
+import com.android.settings.core.instrumentation.InstrumentedDialogFragment;
+
+public class UpdateRecoveryWarningDialog extends InstrumentedDialogFragment implements
+        DialogInterface.OnClickListener, DialogInterface.OnDismissListener {
+
+    public static final String TAG = "UpdateRecoveryWarningDialog";
+
+    private static final String UPDATE_RECOVERY_PROPERTY = "persist.sys.recovery_update";
+
+    public static void show(Fragment host) {
+        final FragmentManager manager = host.getActivity().getSupportFragmentManager();
+        if (manager.findFragmentByTag(TAG) == null) {
+            final UpdateRecoveryWarningDialog dialog =
+                    new UpdateRecoveryWarningDialog();
+            dialog.setTargetFragment(host, 0 /* requestCode */);
+            dialog.show(manager, TAG);
+        }
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.TYPE_UNKNOWN;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        boolean enabled = SystemProperties.getBoolean(UPDATE_RECOVERY_PROPERTY, false);
+        return new AlertDialog.Builder(getActivity())
+                .setMessage(enabled ?
+                        R.string.update_recovery_off_warning : R.string.update_recovery_on_warning)
+                .setPositiveButton(android.R.string.ok, this /* onClickListener */)
+                .setNegativeButton(android.R.string.cancel, this /* onClickListener */)
+                .create();
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        final UpdateRecoveryDialogHost host = (UpdateRecoveryDialogHost) getTargetFragment();
+        if (host == null) {
+            return;
+        }
+        if (which == DialogInterface.BUTTON_POSITIVE) {
+            host.onUpdateRecoveryDialogConfirmed();
+        } else {
+            host.onUpdateRecoveryDialogDismissed();
+        }
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+        final UpdateRecoveryDialogHost host = (UpdateRecoveryDialogHost) getTargetFragment();
+        if (host == null) {
+            return;
+        }
+        host.onUpdateRecoveryDialogDismissed();
+    }
+}


### PR DESCRIPTION
When enabled, the recovery of the device will be updated with the
version of the installed system.

This squashes the following commits from cm-13.0:
c5a412635a1101c6c4f97e07f97209c650edbd7d development: Add setting for updating recovery
4a78446c3e9eab9c116e1523425d366f401ef13e DevelopmentSettings: Add an opt-out for recovery updater

Change-Id: I519905341b9cba9c2ab09f5d9c6e88f4025a73a7