### PR TITLE
Settings: Fix fallback summary for power_button_instantly_locks prefe…

### DIFF
--- a/src/com/android/settings/security/screenlock/PowerButtonInstantLockPreferenceController.java
+++ b/src/com/android/settings/security/screenlock/PowerButtonInstantLockPreferenceController.java
@@ -78,7 +78,7 @@ public class PowerButtonInstantLockPreferenceController extends AbstractPreferen
                     R.string.lockpattern_settings_power_button_instantly_locks_summary,
                     trustAgentLabel));
         } else {
-            preference.setSummary(R.string.summary_placeholder);
+            preference.setSummary(R.string.summary_empty);
         }
     }
 

--- a/tests/robotests/src/com/android/settings/security/screenlock/PowerButtonInstantLockPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/security/screenlock/PowerButtonInstantLockPreferenceControllerTest.java
@@ -119,7 +119,7 @@ public class PowerButtonInstantLockPreferenceControllerTest {
         mController.updateState(mPreference);
         assertThat(mPreference.isChecked()).isFalse();
         assertThat(mPreference.getSummary()).isEqualTo(mContext.getString(
-                R.string.summary_placeholder));
+                R.string.summary_empty));
     }
 
     @Test


### PR DESCRIPTION
…rence

* Using summary_placeholder instead of summary_empty
  leaves an ugly empty space.

Change-Id: I73a90f1b3203d6cb17e1875dc8163eb67140de89