### PR TITLE
fixup! BasebandVersionPreferenceController: Trim baseband if needed

### DIFF
--- a/src/com/android/settings/deviceinfo/firmwareversion/BasebandVersionPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/BasebandVersionPreferenceController.java
@@ -18,6 +18,7 @@ package com.android.settings.deviceinfo.firmwareversion;
 
 import android.content.Context;
 import android.os.SystemProperties;
+import android.text.TextUtils;
 
 import androidx.annotation.VisibleForTesting;
 
@@ -43,9 +44,10 @@ public class BasebandVersionPreferenceController extends BasePreferenceControlle
     public CharSequence getSummary() {
         String baseband = SystemProperties.get(BASEBAND_PROPERTY,
                 mContext.getString(R.string.device_info_default));
-        String[] basebandArray = baseband.split(",");
-        if (basebandArray != null && basebandArray.length > 0) {
-            return basebandArray[0];
+        for (String str : baseband.split(",")) {
+            if (!TextUtils.isEmpty(str)) {
+                return str;
+            }
         }
         return baseband;
     }


### PR DESCRIPTION
* Some devices return baseband version with leading comma.
* Example: `,MPSS.HI.1.0.c8.10-00002-SDX55_RMTEFS_PACK-2.294836.9.300793.2`

Change-Id: Ibbb69f86c6996bb721999c441460fa98d9c65c3e